### PR TITLE
Require Jenkins Core 2.138.3 to remove implied dependencies + POM facelift

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <role>creator (retired)</role>
       </roles>
     </developer>
+   <!-- TODO: add other maintainers -->
   </developers>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.20</version><!-- which version of Hudson is this plugin built against? -->
+    <version>3.48</version>
   </parent>
 
   <groupId>org.jvnet.hudson.plugins</groupId>
@@ -18,24 +18,27 @@
   <version>2.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Jenkins Extended Read Permission Plugin</name>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Extended+Read+Permission+Plugin</url>
+  <url>https://plugins.jenkins.io/extended-read-permission</url>
 
   <properties>
-    <jenkins.version>1.609.1</jenkins.version>
-    <hpi-plugin.version>1.106</hpi-plugin.version>
+    <jenkins.version>2.138.3</jenkins.version>
+    <java.level>8</java.level>
   </properties>
 
   <developers>
     <developer>
       <id>dty</id>
       <name>Dean Yu</name>
+      <roles>
+        <role>creator (retired)</role>
+      </roles>
     </developer>
   </developers>
 
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <tag>HEAD</tag>
   </scm>
 
@@ -43,14 +46,14 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 </project>


### PR DESCRIPTION
Just made some plugin cleanup while I was around