### PR TITLE
JEP-224 - Add a `Overall/SystemRead` permission enabler controlled by the `jenkins.security.SystemReadPermission` system property for Jenkins 2.222+ + Add a Beta `hudson.plugins.extendedread.SystemReadPermission#SYSTEM_READ` permission entity for plugin developers who want to use the permission without updating the Jenkins core dependency

### DIFF
--- a/src/main/java/hudson/plugins/extendedread/SystemReadPermission.java
+++ b/src/main/java/hudson/plugins/extendedread/SystemReadPermission.java
@@ -18,7 +18,7 @@ public class SystemReadPermission {
     static {
         Permission systemRead;
         try {
-            systemRead = (Permission) ReflectionUtils.getPublicProperty(Jenkins.getInstance(), "SYSTEM_READ");
+            systemRead = (Permission) ReflectionUtils.getPublicProperty(Jenkins.get(), "SYSTEM_READ");
         } catch (IllegalArgumentException | InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
             LOGGER.log(Level.FINE, "Couldn't find system read permission, falling back to ADMINISTER", e);
             systemRead = ADMINISTER;

--- a/src/main/java/hudson/plugins/extendedread/SystemReadPermission.java
+++ b/src/main/java/hudson/plugins/extendedread/SystemReadPermission.java
@@ -1,0 +1,26 @@
+package hudson.plugins.extendedread;
+
+import hudson.security.Permission;
+import hudson.util.ReflectionUtils;
+import java.lang.reflect.InvocationTargetException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jenkins.model.Jenkins;
+
+import static jenkins.model.Jenkins.ADMINISTER;
+
+public class SystemReadPermission {
+
+    private static final Logger LOGGER = Logger.getLogger(SystemReadPermission.class.getName());
+
+    public static Permission SYSTEM_READ;
+
+    static {
+        try {
+            SYSTEM_READ = (Permission) ReflectionUtils.getPublicProperty(Jenkins.getInstance(), "SYSTEM_READ");
+        } catch (IllegalArgumentException | InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+            LOGGER.log(Level.FINE, "Couldn't find system read permission, falling back to ADMINISTER", e);
+            SYSTEM_READ = ADMINISTER;
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/extendedread/SystemReadPermission.java
+++ b/src/main/java/hudson/plugins/extendedread/SystemReadPermission.java
@@ -13,14 +13,17 @@ public class SystemReadPermission {
 
     private static final Logger LOGGER = Logger.getLogger(SystemReadPermission.class.getName());
 
-    public static Permission SYSTEM_READ;
+    public static final Permission SYSTEM_READ;
 
     static {
+        Permission systemRead;
         try {
-            SYSTEM_READ = (Permission) ReflectionUtils.getPublicProperty(Jenkins.getInstance(), "SYSTEM_READ");
+            systemRead = (Permission) ReflectionUtils.getPublicProperty(Jenkins.getInstance(), "SYSTEM_READ");
         } catch (IllegalArgumentException | InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
             LOGGER.log(Level.FINE, "Couldn't find system read permission, falling back to ADMINISTER", e);
-            SYSTEM_READ = ADMINISTER;
+            systemRead = ADMINISTER;
         }
+
+        SYSTEM_READ = systemRead;
     }
 }

--- a/src/main/java/hudson/plugins/extendedread/SystemReadPermission.java
+++ b/src/main/java/hudson/plugins/extendedread/SystemReadPermission.java
@@ -20,7 +20,7 @@ public class SystemReadPermission {
 
     static {
         Permission systemRead;
-        try {
+        try { // System Read is available starting from Jenkins 2.222 (https://jenkins.io/changelog/#v2.222). See JEP-224 for more info
             systemRead = (Permission) ReflectionUtils.getPublicProperty(Jenkins.get(), "SYSTEM_READ");
         } catch (IllegalArgumentException | InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
             LOGGER.log(Level.FINE, "Couldn't find system read permission, falling back to ADMINISTER", e);

--- a/src/main/java/hudson/plugins/extendedread/SystemReadPermission.java
+++ b/src/main/java/hudson/plugins/extendedread/SystemReadPermission.java
@@ -6,9 +6,12 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
 
 import static jenkins.model.Jenkins.ADMINISTER;
 
+@Restricted(Beta.class)
 public class SystemReadPermission {
 
     private static final Logger LOGGER = Logger.getLogger(SystemReadPermission.class.getName());

--- a/src/main/java/hudson/plugins/extendedread/SystemReadPermissionEnabler.java
+++ b/src/main/java/hudson/plugins/extendedread/SystemReadPermissionEnabler.java
@@ -1,0 +1,19 @@
+package hudson.plugins.extendedread;
+
+import hudson.Extension;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Extension
+@Restricted(NoExternalUse.class)
+public class SystemReadPermissionEnabler {
+
+    @Initializer(after = InitMilestone.PLUGINS_STARTED)
+    public static void enableSystemReadPermission() {
+        if (System.getProperty("jenkins.security.SystemReadPermission") == null) {
+            SystemReadPermission.SYSTEM_READ.setEnabled(true);
+        }
+    }
+}


### PR DESCRIPTION
Downstream of: https://github.com/jenkinsci/jenkins/pull/4149

@batmat what do you think of this living here?

cc @oleg-nenashev 

(haven't added a test here as it wouldn't show anything without bumping the jenkins core version)