### PR TITLE
Enable Agent/ExtendedRead

### DIFF
--- a/src/main/java/hudson/plugins/extendedread/ExtendedReadPermissionEnabler.java
+++ b/src/main/java/hudson/plugins/extendedread/ExtendedReadPermissionEnabler.java
@@ -1,5 +1,6 @@
 package hudson.plugins.extendedread;
 
+import hudson.model.Computer;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -15,6 +16,7 @@ public class ExtendedReadPermissionEnabler {
     public static void enableExtendedReadPermission() {
         if (System.getProperty("hudson.security.ExtendedReadPermission") == null) {
             Item.EXTENDED_READ.setEnabled(true);
+            Computer.EXTENDED_READ.setEnabled(true);
         }
     }
 }

--- a/src/test/java/hudson/plugins/extendedread/ExtendedReadPermissionTest.java
+++ b/src/test/java/hudson/plugins/extendedread/ExtendedReadPermissionTest.java
@@ -9,6 +9,7 @@ package hudson.plugins.extendedread;
 
 import static org.junit.Assert.assertTrue;
 
+import hudson.model.Computer;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -25,7 +26,12 @@ public class ExtendedReadPermissionTest {
     public JenkinsRule j =  new JenkinsRule();
 
     @Test
-    public void testExtendedReadPermissionEnabled() throws Exception {
+    public void testItemExtendedReadPermissionEnabled() throws Exception {
         assertTrue(Item.EXTENDED_READ.getEnabled());
+    }
+
+    @Test
+    public void testComputerExtendedReadPermissionEnabled() throws Exception {
+        assertTrue(Computer.EXTENDED_READ.getEnabled());
     }
 }


### PR DESCRIPTION
See:

https://github.com/jenkinsci/jenkins/pull/4531
https://github.com/jenkins-infra/jenkins.io/pull/3279

Requires https://github.com/jenkinsci/jenkins/pull/4531 to actually do anything other than allow access to a couple of API endpoints

Note: the same system property is used in core to manage enable / disable so I've wrapped it in the same code block

Fixes https://github.com/jenkinsci/extended-read-permission-plugin/issues/12